### PR TITLE
Fix strict cert issue on Python 2.7.9 plus added support of bucket names

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -48,7 +48,7 @@ class SyncS3():
                     aws_access_key_id=self.AWS_ACCESS_KEY,
                     aws_secret_access_key=self.AWS_SECRET_KEY)
 
-        return conn.get_bucket(self.BUCKET_NAME, validate=False)
+        return conn.get_bucket(self.BUCKET_NAME)
 
 
     def _sync_log_files(self, prefix=None):


### PR DESCRIPTION
Fix strict cert issue on Python 2.7.9 plus added support of bucket names with dots.
Reference:
https://github.com/boto/boto/issues/2836
